### PR TITLE
requesting key press for user to continue

### DIFF
--- a/menus.pl
+++ b/menus.pl
@@ -100,7 +100,9 @@ game_details(GameID) :-
     write("Nome:"),nl,
     write(Name),nl,
     write("Descrição:"),nl,
-    write(Description), nl.
+    write(Description), nl,
+    nl, write("Pressione ENTER para retornar ao menu..."), nl,
+    get_char(_).
 
 /*
 explore_recommandations(Id, Name) :-


### PR DESCRIPTION
Um comando de clear 'limpava' a recomendação feita pelo app antes que o usuário pudesse vê-la. 
Agora é necessário pressionar enter, enquanto na tela de recomendação, para retornar ao menu.