### PR TITLE
Fix/show_recommendation

### DIFF
--- a/main.pl
+++ b/main.pl
@@ -25,7 +25,8 @@ by_genre:-
 show_recommendation:-
     findall(X, find_games(X), RecommendationList),
     nth0(0, RecommendationList, Id),
-    game_details(Id).
+    game_details(Id);
+    show_error.
 
 show_random_recommendation:-
     random_between(0,99,RandonIndex),

--- a/menus.pl
+++ b/menus.pl
@@ -129,9 +129,13 @@ game_details(GameID) :-
 show_game_as_list_item(GameID) :- 
     game(GameID, Name, _, _, _, Cat, Gen, _, _, _), 
     format('Nome: ~w', Name), nl,
-    format('Genêro (s): ~w', [Gen]), nl,
+    format('Gênero (s): ~w', [Gen]), nl,
     format('Categoria (s): ~w', [Cat]), nl, nl, nl.
 
+show_error :-
+    write("Não foi encontrado nenhum jogo com os filtros selecionados."),nl,nl,
+    write("Pressione ENTER para retornar ao menu..."), nl,
+    get_char(_).
 
 /*
 explore_recommandations(Id, Name) :-


### PR DESCRIPTION
Na opção de recomendação por preferências foi adicionada uma mensagem de erro que é apresentada para o usuário caso nenhum jogo tenha sido encontrado com os filtros selecionados. Após isso o usuário pode retornar ao menu.